### PR TITLE
Conflict handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+Be aware that this project is still v0.y.z which means that anything can change anytime:
+
+> "4. Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The
+> public API SHOULD NOT be considered stable."
+>
+> (Semantic Versioning Specification)
+
+## Indicating incompatible changes on major version zero
+
+We defined for this project that while being on major version zero we mark incompatible changes with
+new minor version numbers. Please note that this is no version handling covered by `Semver`.
+
+## 0.1.0 - Not released yet
+
+To make the generation of parse tables more flexible we added a way to control this process.
+The trait `Config` is used for this and a custom implementation can be provided to deviate from the
+default.
+To keep the default behavior as in previous versions the user can use the `DefaultConfig` structure
+that provides the implementation of the standard behavior.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lalr"
-version = "0.0.2"
+version = "0.1.0"
 authors = ["Geoffry Song <goffrie@gmail.com>"]
 
 description = "a library for creating LALR(1) parsers from context-free grammars"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,14 +1,14 @@
 //! This module provides a trait for the configuration of the parse table generation process.
 //!
-//! The uer can implement this trait to provide a custom configuration.
+//! The user can implement this trait to provide a custom configuration.
 //! The default configuration is provided by the default implementation of this trait.
 //!
 use crate::Rhs;
 
 /// The trait for configuration.
 pub trait Config<T, N, A> {
-    /// Resolve shift-reduce conflict in favor of shift.
-    /// This method returns true if shift should be resolved in favor of shift.
+    /// `resolve_shift_reduse_conflict_in_favor_of_shift` returns true if shift should be resolved
+    /// in favor of shift.
     /// To mimic a behavior of Yacc, this method should return true.
     /// See, https://www.gnu.org/savannah-checkouts/gnu/bison/manual/html_node/Shift_002fReduce.html
     /// and https://www.ibm.com/docs/en/zos/2.2.0?topic=ambiguities-rules-help-remove
@@ -17,7 +17,7 @@ pub trait Config<T, N, A> {
     /// If this method returns false, shift-reduce conflict is not resolved and the parse table
     /// generation will fail with an error.
     /// This is the default behavior of this create.
-    /// It also means that the parser will anly accept LALR(1) grammars.
+    /// It also means that the parser will only accept pure LALR(1) grammars.
     ///
     /// If this method returns true, shift-reduce conflict is resolved in favor of shift and the
     /// parser will accept a wider range of grammars.
@@ -48,6 +48,7 @@ pub trait Config<T, N, A> {
 pub struct DefaultConfig<T, N, A> {
     _phantom: std::marker::PhantomData<(T, N, A)>,
 }
+
 /// The implementation of the default configuration.
 impl<T, N, A> DefaultConfig<T, N, A> {
     /// Create a new default configuration.
@@ -57,10 +58,12 @@ impl<T, N, A> DefaultConfig<T, N, A> {
         }
     }
 }
+
 /// The default implementation of the configuration.
 impl<T, N, A> Default for DefaultConfig<T, N, A> {
     fn default() -> Self {
         DefaultConfig::new()
     }
 }
+
 impl<T, N, A> Config<T, N, A> for DefaultConfig<T, N, A> {}

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use crate::Rhs;
 pub trait Config<T, N, A> {
     /// `resolve_shift_reduse_conflict_in_favor_of_shift` returns true if shift should be resolved
     /// in favor of shift.
-    /// To mimic a behavior of Yacc, this method should return true.
+    /// To mimic a behavior of Bison/Yacc, this method should return true.
     /// See, https://www.gnu.org/savannah-checkouts/gnu/bison/manual/html_node/Shift_002fReduce.html
     /// and https://www.ibm.com/docs/en/zos/2.2.0?topic=ambiguities-rules-help-remove
     /// for more information.
@@ -20,9 +20,23 @@ pub trait Config<T, N, A> {
     /// It also means that the parser will only accept pure LALR(1) grammars.
     ///
     /// If this method returns true, shift-reduce conflict is resolved in favor of shift and the
-    /// parser will accept a wider range of grammars.
+    /// resulting parser will accept a wider range of grammars.
     /// Also, the parse table generation will return warnings for shift-reduce conflicts.
     fn resolve_shift_reduse_conflict_in_favor_of_shift(&self) -> bool {
+        false
+    }
+
+    /// `warn_on_resolved_conflicts` returns true if a warning should be emitted when
+    /// a reduce-reduce or a shift-reduce conflict is resolved.
+    /// A reduce-reduce conflict is resolved by selecting the rule with the highest priority. This
+    /// means that the methode `priority_of` should provide meaningfull values to resolve the
+    /// conflicts in a deterministic way.
+    /// A shift-reduce conflict is resolved by selecting the shift action. This can only be the case
+    /// when 'resolve_shift_reduse_conflict_in_favor_of_shift' returns true.
+    ///
+    /// If this method returns false, no warnings are emitted when a conflict is resolved.
+    /// This is the default behavior of this crate.
+    fn warn_on_resolved_conflicts(&self) -> bool {
         false
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@
 //! The user can implement this trait to provide a custom configuration.
 //! The default configuration is provided by the default implementation of this trait.
 //!
-use crate::Rhs;
+use crate::{LR1ResolvedConflict, Rhs};
 
 /// The trait for configuration.
 pub trait Config<T, N, A> {
@@ -26,18 +26,27 @@ pub trait Config<T, N, A> {
         false
     }
 
-    /// `warn_on_resolved_conflicts` returns true if a warning should be emitted when
-    /// a reduce-reduce or a shift-reduce conflict is resolved.
+    /// `warn_on_resolved_conflicts` returns a reported function if a warnings should be emitted
+    /// when reduce-reduce or a shift-reduce conflicts are resolved.
     /// A reduce-reduce conflict is resolved by selecting the rule with the highest priority. This
     /// means that the methode `priority_of` should provide meaningfull values to resolve the
     /// conflicts in a deterministic way.
     /// A shift-reduce conflict is resolved by selecting the shift action. This can only be the case
-    /// when 'resolve_shift_reduse_conflict_in_favor_of_shift' returns true.
+    /// when `resolve_shift_reduse_conflict_in_favor_of_shift` returns true.
     ///
-    /// If this method returns false, no warnings are emitted when a conflict is resolved.
+    /// Warnings are emmitted by calling the returned function with the resolved conflict.
+    /// This configures the handling of warnings and gives the client full control over the way
+    /// warnings are emitted.
+    ///
+    /// If this method returns `None`, no warnings are emitted when a conflict is resolved.
     /// This is the default behavior of this crate.
-    fn warn_on_resolved_conflicts(&self) -> bool {
-        false
+    fn warn_on_resolved_conflicts<'a>(&self) -> Option<impl Fn(LR1ResolvedConflict<'a, T, N, A>)>
+    where
+        T: 'a,
+        N: 'a,
+        A: 'a,
+    {
+        None::<fn(LR1ResolvedConflict<'a, T, N, A>)>
     }
 
     /// `reduce_on` is a predicate, allowing you to control certain reduce rules based on the

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,66 @@
+//! This module provides a trait for the configuration of the parse table generation process.
+//!
+//! The uer can implement this trait to provide a custom configuration.
+//! The default configuration is provided by the default implementation of this trait.
+//!
+use crate::Rhs;
+
+/// The trait for configuration.
+pub trait Config<T, N, A> {
+    /// Resolve shift-reduce conflict in favor of shift.
+    /// This method returns true if shift should be resolved in favor of shift.
+    /// To mimic a behavior of Yacc, this method should return true.
+    /// See, https://www.gnu.org/savannah-checkouts/gnu/bison/manual/html_node/Shift_002fReduce.html
+    /// and https://www.ibm.com/docs/en/zos/2.2.0?topic=ambiguities-rules-help-remove
+    /// for more information.
+    ///
+    /// If this method returns false, shift-reduce conflict is not resolved and the parse table
+    /// generation will fail with an error.
+    /// This is the default behavior of this create.
+    /// It also means that the parser will anly accept LALR(1) grammars.
+    ///
+    /// If this method returns true, shift-reduce conflict is resolved in favor of shift and the
+    /// parser will accept a wider range of grammars.
+    /// Also, the parse table generation will return warnings for shift-reduce conflicts.
+    fn resolve_shift_reduse_conflict_in_favor_of_shift(&self) -> bool {
+        false
+    }
+
+    /// `reduce_on` is a predicate, allowing you to control certain reduce rules based on the
+    /// lookahead token. This function takes two parameters: the rule, given by its right-hand
+    /// side, and the lookahead token (or `None` for EOF). You can use this to resolve
+    /// shift-reduce conflicts. For example, you can solve the "dangling else" problem by
+    /// forbidding the reduce action on an `else` token.
+    fn reduce_on(&self, _rhs: &Rhs<T, N, A>, _lookahead: Option<&T>) -> bool {
+        true
+    }
+
+    /// `priority_of` allows you to resolve reduce-reduce conflicts, by giving reduce rules
+    /// different "priorities". This takes the same parameters as `reduce_on`, so you can vary
+    /// the priority based on the lookahead token. If there would be a reduce-reduce conflict
+    /// between rules, but they have different priority, the one with higher priority is used.
+    fn priority_of(&self, _rhs: &Rhs<T, N, A>, _lookahead: Option<&T>) -> i32 {
+        0
+    }
+}
+
+/// The default configuration.
+pub struct DefaultConfig<T, N, A> {
+    _phantom: std::marker::PhantomData<(T, N, A)>,
+}
+/// The implementation of the default configuration.
+impl<T, N, A> DefaultConfig<T, N, A> {
+    /// Create a new default configuration.
+    pub fn new() -> Self {
+        DefaultConfig {
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+/// The default implementation of the configuration.
+impl<T, N, A> Default for DefaultConfig<T, N, A> {
+    fn default() -> Self {
+        DefaultConfig::new()
+    }
+}
+impl<T, N, A> Config<T, N, A> for DefaultConfig<T, N, A> {}

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,7 +114,7 @@ impl<'a, T, N, A> ConflictWarner<'a, T, N, A> {
         ConflictWarner { config }
     }
 
-    /// Issue a warning for a resolved reduce-reduce conflict.
+    /// Issue a warning for a resolved shift-reduce conflict.
     /// The lifetime 'b is used to ensure that the state is not borrowed for longer than necessary.
     pub fn warn_shift_reduce<'b>(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,26 @@ pub enum LR1Conflict<'a, T: 'a, N: 'a, A: 'a> {
     },
 }
 
+/// The applied resolution of an LR(1) conflict.
+#[derive(Debug)]
+pub enum LRConflictResolution {
+    /// Resolved a shift-reduce conflict by shifting.
+    ShiftOverReduce,
+    /// Resolved a reduce-reduce conflict by selecting the first rule.
+    ReduceFirstRule,
+    /// Resolved a reduce-reduce conflict by selecting the second rule.
+    ReduceSecondRule,
+}
+
+/// The resolution of an LR(1) conflict. It is reported to the user during parse table generation.
+#[derive(Debug)]
+pub struct LR1ResolvedConflict<'a, T: 'a, N: 'a, A: 'a> {
+    /// The conflict that was resolved.
+    pub conflict: LR1Conflict<'a, T, N, A>,
+    /// The resolution that was applied.
+    pub applied_resolution: LRConflictResolution,
+}
+
 impl<T: Ord, N: Ord, A> Grammar<T, N, A> {
     /// Create the LR(0) state machine for a grammar.
     pub fn lr0_state_machine<'a>(&'a self) -> LR0StateMachine<'a, T, N, A> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -218,3 +218,218 @@ fn test_lalr1_no_conflict() {
         panic!("Expected a parse table");
     }
 }
+
+struct TestConfig<'a> {
+    calls: RefCell<Vec<LR1ResolvedConflict<'a, &'a str, &'a str, ()>>>,
+}
+
+impl<'a> TestConfig<'a> {
+    fn new() -> Self {
+        TestConfig {
+            calls: RefCell::new(vec![]),
+        }
+    }
+}
+
+impl<'a> Config<'a, &'a str, &'a str, ()> for TestConfig<'a> {
+    fn resolve_shift_reduce_conflict_in_favor_of_shift(&self) -> bool {
+        true
+    }
+
+    fn warn_on_resolved_conflicts(&self) -> bool {
+        true
+    }
+
+    fn on_resolved_conflict(&self, conflict: LR1ResolvedConflict<'a, &'a str, &'a str, ()>) {
+        println!("\nResolved conflict: {:?}", conflict);
+        self.calls.borrow_mut().push(conflict);
+    }
+}
+
+#[test]
+fn test_lalr1_resolved_shift_reduce_conflict() {
+    // The grammar resemples this example
+    // Conflict
+    //     : Stmt
+    //     ;
+    // Stmt
+    //     : 'if' '(' cond ')' Stmt
+    //     | 'if' '(' cond ')' Stmt 'else'^ Stmt
+    //     |
+    //     ;
+    // cond: 'true'
+    //     | 'false'
+    //     ;
+    // The grammar is ambigous, but the shift-reduce conflict can be resolved by shifting.
+    // The shift-reduce conflict in this grammar arises from the ambiguity of the `else` clause in
+    // an `if` statement. This is often referred to as the "dangling else" problem.
+    // Here's the issue: when you have nested `if` statements, it's unclear to which `if` an `else`
+    // belongs. For example, consider the following code:
+
+    // ```
+    // if (Cond) if (Cond) Stmt else Stmt
+    // ```
+
+    // This could be interpreted in two ways:
+
+    // 1. As `if (Cond) { if (Cond) Stmt else Stmt }` (where the `else` belongs to the inner `if`)
+    // 2. As `if (Cond) { if (Cond) Stmt } else Stmt` (where the `else` belongs to the outer `if`)
+
+    // In the first interpretation, we "reduce" when we see the `else` (i.e., we finish the inner
+    // `if` statement). In the second interpretation, we "shift" (i.e., we consider the `else` as
+    // part of the outer `if` statement).
+
+    // This is a shift-reduce conflict. The parser doesn't know whether to shift (add the `else` to
+    // the stack for further processing) or reduce (use the `else` to complete a statement and
+    // remove symbols from the stack).
+
+    // Most parser generators, including YACC and Bison, resolve this conflict by shifting, which
+    // corresponds to the first interpretation (the `else` belongs to the inner `if`). This is
+    // generally what we want in programming languages -- it's how C, C++, Java, and most other
+    // languages handle this ambiguity.
+    let g = Grammar {
+        rules: map![
+            "Conflict" => vec![
+                rhs(vec![Nonterminal("Stmt")], ()),
+            ],
+            "Stmt" => vec![
+                rhs(vec![
+                    Terminal("if"),
+                    Terminal("("),
+                    Nonterminal("Cond"),
+                    Terminal(")"),
+                    Nonterminal("Stmt")], ()),
+                rhs(vec![
+                    Terminal("if"),
+                    Terminal("("),
+                    Nonterminal("Cond"),
+                    Terminal(")"),
+                    Nonterminal("Stmt"),
+                    Terminal("else"),
+                    Nonterminal("Stmt")], ()),
+                rhs(vec![], ()),
+            ],
+            "Cond" => vec![
+                rhs(vec![Terminal("true")], ()),
+                rhs(vec![Terminal("false")], ()),
+            ]
+        ],
+        start: "Conflict",
+    };
+
+    let pt_expected = LR1ParseTable::<&str, &str, ()> {
+        states: vec![
+            LR1State {
+                eof: Some(LRAction::Reduce(&"Stmt", &g.rules.get("Stmt").unwrap()[2])),
+                lookahead: map! {
+                    &"if" => LRAction::Shift(1)
+                },
+                goto: map! {
+                    &"Stmt" => 2
+                },
+            },
+            LR1State {
+                eof: None,
+                lookahead: map! {
+                    &"(" => LRAction::Shift(3)
+                },
+                goto: BTreeMap::new(),
+            },
+            LR1State {
+                eof: Some(LRAction::Accept),
+                lookahead: BTreeMap::new(),
+                goto: BTreeMap::new(),
+            },
+            LR1State {
+                eof: None,
+                lookahead: map! {
+                    &"false" => LRAction::Shift(4),
+                    &"true" => LRAction::Shift(5)
+                },
+                goto: map! {
+                    &"Cond" => 6
+                },
+            },
+            LR1State {
+                eof: None,
+                lookahead: map! {
+                    &")" => LRAction::Reduce(
+                        &"Cond",
+                        &g.rules.get("Cond").unwrap()[1],
+                    )
+                },
+                goto: BTreeMap::new(),
+            },
+            LR1State {
+                eof: None,
+                lookahead: map! {
+                    &")" => LRAction::Reduce(
+                        &"Cond",
+                        &g.rules.get("Cond").unwrap()[0],
+                    )
+                },
+                goto: BTreeMap::new(),
+            },
+            LR1State {
+                eof: None,
+                lookahead: map! {
+                    &")" => LRAction::Shift(7)
+                },
+                goto: BTreeMap::new(),
+            },
+            LR1State {
+                eof: Some(LRAction::Reduce(&"Stmt", &g.rules.get("Stmt").unwrap()[2])),
+                lookahead: map! {
+                    &"else" => LRAction::Reduce(
+                        &"Stmt",
+                        &g.rules.get("Stmt").unwrap()[2]
+                    ),
+                    &"if" => LRAction::Shift(1)
+                },
+                goto: map! {
+                    &"Stmt" => 8
+                },
+            },
+            LR1State {
+                eof: Some(LRAction::Reduce(&"Stmt", &g.rules.get("Stmt").unwrap()[0])),
+                lookahead: map! {
+                    &"else" => LRAction::Shift(9)
+                },
+                goto: BTreeMap::new(),
+            },
+            LR1State {
+                eof: Some(LRAction::Reduce(&"Stmt", &g.rules.get("Stmt").unwrap()[2])),
+                lookahead: map! {
+                    &"else" => LRAction::Reduce(
+                        &"Stmt",
+                        &g.rules.get("Stmt").unwrap()[2]
+                    ),
+                    &"if" => LRAction::Shift(1)
+                },
+                goto: map! {
+                    &"Stmt" => 10
+                },
+            },
+            LR1State {
+                eof: Some(LRAction::Reduce(&"Stmt", &g.rules.get("Stmt").unwrap()[1])),
+                lookahead: map! {
+                    &"else" => LRAction::Reduce(
+                        &"Stmt",
+                        &g.rules.get("Stmt").unwrap()[1]
+                    )
+                },
+                goto: BTreeMap::new(),
+            },
+        ],
+    };
+
+    let config = TestConfig::new();
+    if let Ok(pt) = g.lalr1(&config) {
+        assert_eq!(pt, pt_expected);
+        // The conflict is actually resolved twice
+        // I'm not sure why it's resolved twice, maybe this is a problem in the implementation
+        assert_eq!(config.calls.borrow().len(), 2);
+    } else {
+        panic!("Expected a parse table");
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,5 @@
+use crate::config::DefaultConfig;
+
 use super::*;
 use std::collections::BTreeMap;
 
@@ -91,6 +93,128 @@ fn test_extended_grammar() {
 #[test]
 fn test_lalr1() {
     let g = grammar();
+    let c = DefaultConfig::new();
     // FIXME: write a test
-    assert!(g.lalr1(|_, _| true, |_, _| 0).is_ok());
+    assert!(g.lalr1(&c).is_ok());
+}
+
+#[test]
+fn test_lalr1_no_conflict() {
+    // This grammar was taken from https://github.com/jsinger67/parol/blob/main/examples/list_lr/list.par
+    let g = Grammar {
+        rules: map![
+            "List" => vec![
+                rhs(vec![Nonterminal("ListOpt")], ()),
+            ],
+            "ListOpt" => vec![
+                rhs(vec![Nonterminal("Items")], ()),
+                rhs(vec![], ()),
+            ],
+            "Items" => vec![
+                rhs(vec![Nonterminal("Num"), Nonterminal("ItemsList")], ()),
+            ],
+            "ItemsList" => vec![
+                rhs(vec![Nonterminal("ItemsList"), Terminal(","), Nonterminal("Num")], ()),
+                rhs(vec![], ()),
+            ],
+            "Num" => vec![
+                rhs(vec![Terminal("/0|[1-9][0-9]*/")], ()),
+            ]
+        ],
+        start: "List",
+    };
+    let pt_expected = LR1ParseTable::<&str, &str, ()> {
+        states: vec![
+            LR1State {
+                eof: Some(LRAction::Reduce(
+                    &"ListOpt",
+                    &g.rules.get("ListOpt").unwrap()[1],
+                )),
+                lookahead: map! {
+                    &"/0|[1-9][0-9]*/" => LRAction::Shift(1)
+                },
+                goto: map! {
+                    &"Items" => 2,
+                    &"ListOpt" => 3,
+                    &"Num" => 4
+                },
+            },
+            LR1State {
+                eof: Some(LRAction::Reduce(&"Num", &g.rules.get("Num").unwrap()[0])),
+                lookahead: map! {
+                    &"," => LRAction::Reduce(
+                        &"Num",
+                        &g.rules.get("Num").unwrap()[0]
+                    )
+                },
+                goto: BTreeMap::new(),
+            },
+            LR1State {
+                eof: Some(LRAction::Reduce(
+                    &"ListOpt",
+                    &g.rules.get("ListOpt").unwrap()[0],
+                )),
+                lookahead: BTreeMap::new(),
+                goto: BTreeMap::new(),
+            },
+            LR1State {
+                eof: Some(LRAction::Accept),
+                lookahead: BTreeMap::new(),
+                goto: BTreeMap::new(),
+            },
+            LR1State {
+                eof: Some(LRAction::Reduce(
+                    &"ItemsList",
+                    &g.rules.get("ItemsList").unwrap()[1],
+                )),
+                lookahead: map! {
+                    &"," => LRAction::Reduce(
+                        &"ItemsList",
+                        &g.rules.get("ItemsList").unwrap()[1],
+                    )
+                },
+                goto: map! {
+                    &"ItemsList" => 5
+                },
+            },
+            LR1State {
+                eof: Some(LRAction::Reduce(
+                    &"Items",
+                    &g.rules.get("Items").unwrap()[0],
+                )),
+                lookahead: map! {
+                    &"," => LRAction::Shift(6)
+                },
+                goto: BTreeMap::new(),
+            },
+            LR1State {
+                eof: None,
+                lookahead: map! {
+                    &"/0|[1-9][0-9]*/" => LRAction::Shift(1)
+                },
+                goto: map! {
+                    &"Num" => 7
+                },
+            },
+            LR1State {
+                eof: Some(LRAction::Reduce(
+                    &"ItemsList",
+                    &g.rules.get("ItemsList").unwrap()[0],
+                )),
+                lookahead: map! {
+                    &"," => LRAction::Reduce(
+                        &"ItemsList",
+                        &g.rules.get("ItemsList").unwrap()[0],
+                    )
+                },
+                goto: BTreeMap::new(),
+            },
+        ],
+    };
+
+    if let Ok(pt) = g.lalr1(&DefaultConfig::new()) {
+        assert_eq!(pt, pt_expected);
+    } else {
+        panic!("Expected a parse table");
+    }
 }


### PR DESCRIPTION
I've been working on a more general solution for how to control the handling of conflicts during parse table generation.

The original implementation already provided two parameters `reduce_on` and `priority_of` that could properly resolve any conflicts.
However, the problem with automatic parser generators is that it is not easy to describe which conflicts should be solved automatically and which should not.

I therefore wanted a way to create behavior like YACC, namely that in general all shift-reduce conflicts can be resolved by favoring shift.

In order not to inflate the call parameters of the `lalr` function excessively, I introduced a `Config` trait that allows the configuration of the behavior.

The previous functions `reduce_on` and `priority_of` are now part of this trait and ensure that the previous functionality is retained. The `Config` trait allows further configuration options, such as the YACC-like behavior described above. You can also configure whether such automatically resolved conflicts shall be reported as warnings.

I have provided tests for all new functionality.

I hope these extensions fit into the general concept of this crate. In any case, I am convinced that the expanded configuration options can appeal to more users.
